### PR TITLE
Add ticket templates for frontend, backend, and integration

### DIFF
--- a/.github/backendticket.md
+++ b/.github/backendticket.md
@@ -1,0 +1,24 @@
+---
+name: Backend Issue
+about: Tickets for the backend
+title: ":robot: Implement ??? "
+assignees: ''
+---
+
+**Description:** As a user, I want to be able to ???
+
+**Location:** file path in repo
+
+**Resources:** 
+
+### Action items
+
+- [ ]  
+- [ ]  
+
+### Definition of done
+
+- Code is written and functions as described.
+- Tests written in pytest have been implemented on the written code and pass.
+- Code is committed to a feature branch.
+- A pull request has been created and successfully reviewed, passing all pipelines.

--- a/.github/frontendticket.md
+++ b/.github/frontendticket.md
@@ -1,0 +1,23 @@
+---
+name: Frontend Issue
+about: Tickets for the frontend
+title: ":paintbrush: Implement ??? "
+assignees: ''
+---
+
+**Description:** As a user, I want to be able to ???
+
+**Location:** file path in repo
+
+**Resources:** 
+
+### Action items
+
+- [ ]  
+- [ ]  
+
+### Definition of done
+
+- Code is written and functions as described.
+- Code is committed to a feature branch.
+- A pull request has been created and successfully reviewed, passing all pipelines.

--- a/.github/integrationticket.md
+++ b/.github/integrationticket.md
@@ -1,0 +1,24 @@
+---
+name: Integration Issue
+about: Tickets for integrating the frontend and backend
+title: ":airplane: Integrate ??? "
+assignees: ''
+---
+
+**Description:** As a user, I want to be able to ???
+
+**Location:** file path in repo
+
+**Resources:** 
+
+### Action items
+
+- [ ]  
+- [ ]  
+
+### Definition of done
+
+- Code is written and functions as described.
+- Backend tests written in pytest have been implemented on the written code and pass.
+- Code is committed to a feature branch.
+- A pull request has been created and successfully reviewed, passing all pipelines.


### PR DESCRIPTION
These are for the GitHub Project, which is where the Kanban Board will be moved to.